### PR TITLE
Update RandomFactionsMod.cs

### DIFF
--- a/Languages/ChineseSimplified/Keyed/Text.xml
+++ b/Languages/ChineseSimplified/Keyed/Text.xml
@@ -11,4 +11,12 @@
   <RaFa.verboseLogging>冗长日志</RaFa.verboseLogging>
   <RaFa.verboseLoggingTT>启用派系创建和其他进程的冗长日志。</RaFa.verboseLoggingTT>
   <RaFa.currentModVersion>已安装 MOD 版本：{0}</RaFa.currentModVersion>
+  <RaFa.randomFactionCount>随机派系数量</RaFa.randomFactionCount>
+  <RaFa.randomFactionCountTT>世界生成时生成的随机派系数量（默认：4）。</RaFa.randomFactionCountTT>
+  <RaFa.randomTradeFactionCount>随机文明派系数量</RaFa.randomTradeFactionCount>
+  <RaFa.randomTradeFactionCountTT>世界生成时生成的随机文明派系数量（默认：2）。</RaFa.randomTradeFactionCountTT>  
+  <RaFa.randomRoughFactionCount>随机粗犷派系数量</RaFa.randomRoughFactionCount>
+  <RaFa.randomRoughFactionCountTT>世界生成时生成的随机粗犷派系数量（默认：2）。</RaFa.randomRoughFactionCountTT>
+  <RaFa.randomPirateFactionCount>随机敌对派系数量</RaFa.randomPirateFactionCount>
+  <RaFa.randomPirateFactionCountTT>世界生成时生成的随机永久敌对派系数量（默认：1）。</RaFa.randomPirateFactionCountTT>
 </LanguageData>

--- a/Languages/English/Keyed/Text.xml
+++ b/Languages/English/Keyed/Text.xml
@@ -10,4 +10,12 @@
   <RaFa.verboseLogging>Verbose logging</RaFa.verboseLogging>
   <RaFa.verboseLoggingTT>Enables verbose logging of faction creation and other processes.</RaFa.verboseLoggingTT>
   <RaFa.currentModVersion>Installed mod-version: {0}</RaFa.currentModVersion>
+  <RaFa.randomFactionCount>Random Factions Count</RaFa.randomFactionCount>
+  <RaFa.randomFactionCountTT>Number of random factions to generate at world generation (default: 4).</RaFa.randomFactionCountTT>
+  <RaFa.randomTradeFactionCount>Random Civil Factions Count</RaFa.randomTradeFactionCount>
+  <RaFa.randomTradeFactionCountTT>Number of random civil factions to generate at world generation (default: 2).</RaFa.randomTradeFactionCountTT>  
+  <RaFa.randomRoughFactionCount>Random Rough Factions Count</RaFa.randomRoughFactionCount>
+  <RaFa.randomRoughFactionCountTT>Number of random rough factions to generate at world generation (default: 2).</RaFa.randomRoughFactionCountTT>
+  <RaFa.randomPirateFactionCount>Random Pirate Factions Count</RaFa.randomPirateFactionCount>
+  <RaFa.randomPirateFactionCountTT>Number of random pirate factions to generate at world generation (default: 1).</RaFa.randomPirateFactionCountTT>
 </LanguageData>

--- a/Languages/English/Keyed/Text.xml
+++ b/Languages/English/Keyed/Text.xml
@@ -16,6 +16,6 @@
   <RaFa.randomTradeFactionCountTT>Number of random civil factions to generate at world generation (default: 2).</RaFa.randomTradeFactionCountTT>  
   <RaFa.randomRoughFactionCount>Random Rough Factions Count</RaFa.randomRoughFactionCount>
   <RaFa.randomRoughFactionCountTT>Number of random rough factions to generate at world generation (default: 2).</RaFa.randomRoughFactionCountTT>
-  <RaFa.randomPirateFactionCount>Random Pirate Factions Count</RaFa.randomPirateFactionCount>
-  <RaFa.randomPirateFactionCountTT>Number of random pirate factions to generate at world generation (default: 1).</RaFa.randomPirateFactionCountTT>
+  <RaFa.randomPirateFactionCount>Random Hostile Factions Count</RaFa.randomPirateFactionCount>
+  <RaFa.randomPirateFactionCountTT>Number of random always hostile factions to generate at world generation (default: 1).</RaFa.randomPirateFactionCountTT>
 </LanguageData>

--- a/Languages/French/Keyed/Text.xml
+++ b/Languages/French/Keyed/Text.xml
@@ -11,4 +11,12 @@
   <RaFa.verboseLogging>Journalisation verbeuse</RaFa.verboseLogging>
   <RaFa.verboseLoggingTT>Active la journalisation de la création de factions et d'autres processus.</RaFa.verboseLoggingTT>
   <RaFa.currentModVersion>Version installée du mod : {0}</RaFa.currentModVersion>
+  <RaFa.randomFactionCount>Nombre de factions aléatoires</RaFa.randomFactionCount>
+  <RaFa.randomFactionCountTT>Nombre de factions aléatoires à générer lors de la génération du monde (par défaut : 4).</RaFa.randomFactionCountTT>
+  <RaFa.randomTradeFactionCount>Nombre de factions civiles aléatoires</RaFa.randomTradeFactionCount>
+  <RaFa.randomTradeFactionCountTT>Nombre de factions civiles aléatoires à générer lors de la génération du monde (par défaut : 2).</RaFa.randomTradeFactionCountTT>  
+  <RaFa.randomRoughFactionCount>Nombre de factions rudes aléatoires</RaFa.randomRoughFactionCount>
+  <RaFa.randomRoughFactionCountTT>Nombre de factions rudes aléatoires à générer lors de la génération du monde (par défaut : 2).</RaFa.randomRoughFactionCountTT>
+  <RaFa.randomPirateFactionCount>Nombre de factions hostiles aléatoires</RaFa.randomPirateFactionCount>
+  <RaFa.randomPirateFactionCountTT>Nombre de factions toujours hostiles à générer lors de la génération du monde (par défaut : 1).</RaFa.randomPirateFactionCountTT>
 </LanguageData>

--- a/Languages/German/Keyed/Text.xml
+++ b/Languages/German/Keyed/Text.xml
@@ -11,4 +11,12 @@
   <RaFa.verboseLogging>Ausführliche Protokollierung</RaFa.verboseLogging>
   <RaFa.verboseLoggingTT>Ermöglicht die ausführliche Protokollierung der Fraktionserstellung und anderer Prozesse.</RaFa.verboseLoggingTT>
   <RaFa.currentModVersion>Installierte Mod-Version: {0}</RaFa.currentModVersion>
+  <RaFa.randomFactionCount>Anzahl zufälliger Fraktionen</RaFa.randomFactionCount>
+  <RaFa.randomFactionCountTT>Anzahl der zufälligen Fraktionen, die bei der Weltgenerierung erstellt werden (Standard: 4).</RaFa.randomFactionCountTT>
+  <RaFa.randomTradeFactionCount>Anzahl zufälliger ziviler Fraktionen</RaFa.randomTradeFactionCount>
+  <RaFa.randomTradeFactionCountTT>Anzahl der zufälligen zivilen Fraktionen, die bei der Weltgenerierung erstellt werden (Standard: 2).</RaFa.randomTradeFactionCountTT>  
+  <RaFa.randomRoughFactionCount>Anzahl zufälliger rauer Fraktionen</RaFa.randomRoughFactionCount>
+  <RaFa.randomRoughFactionCountTT>Anzahl der zufälligen rauen Fraktionen, die bei der Weltgenerierung erstellt werden (Standard: 2).</RaFa.randomRoughFactionCountTT>
+  <RaFa.randomPirateFactionCount>Anzahl zufälliger feindseliger Fraktionen</RaFa.randomPirateFactionCount>
+  <RaFa.randomPirateFactionCountTT>Anzahl der zufälligen, permanent feindseligen Fraktionen, die bei der Weltgenerierung erstellt werden (Standard: 1).</RaFa.randomPirateFactionCountTT>
 </LanguageData>

--- a/Source/RandomFactions/RandomFactionSettings.cs
+++ b/Source/RandomFactions/RandomFactionSettings.cs
@@ -15,5 +15,9 @@ public class RandomFactionsSettings : ModSettings
         Scribe_Values.Look(ref allowDuplicates, "allowDuplicates");
         Scribe_Values.Look(ref xenoPercent, "xenoPercent", 15);
         Scribe_Values.Look(ref verboseLogging, "verboseLogging");
+        Scribe_Values.Look(ref randomFactionCount, "randomFactionCount", 4);
+        Scribe_Values.Look(ref randomTradeFactionCount, "randomTradeFactionCount", 2);
+        Scribe_Values.Look(ref randomRoughFactionCount, "randomRoughFactionCount", 2);
+        Scribe_Values.Look(ref randomPirateFactionCount, "randomPirateFactionCount", 1);
     }
 }

--- a/Source/RandomFactions/RandomFactionsMod.cs
+++ b/Source/RandomFactions/RandomFactionsMod.cs
@@ -242,6 +242,7 @@ public class RandomFactionsMod : Mod
         }
 
         // Apply faction count settings
+        // The XML defines them as 4 / 2 / 2 / 1 (Any / Civil / Rough / Pirate), this allows user changable Faction counts in settings.
         applyFactionCountSettings();
 
         Logger.Trace("DefsLoaded complete");

--- a/Source/RandomFactions/RandomFactionsMod.cs
+++ b/Source/RandomFactions/RandomFactionsMod.cs
@@ -241,6 +241,9 @@ public class RandomFactionsMod : Mod
             createXenoFactions();
         }
 
+        // Apply faction count settings
+        applyFactionCountSettings();
+
         Logger.Trace("DefsLoaded complete");
     }
 
@@ -331,6 +334,55 @@ public class RandomFactionsMod : Mod
         }
     }
 
+    /// <summary>
+    /// Apply faction count settings to override XML values
+    /// </summary>
+    private void applyFactionCountSettings()
+    {
+        Logger.Trace("Applying faction count settings...");
+
+        // Get the faction defs by their defNames
+        var randomFactionDef = DefDatabase<FactionDef>.GetNamedSilentFail("RF_RandomFaction");
+        var randomTradeFactionDef = DefDatabase<FactionDef>.GetNamedSilentFail("RF_RandomTradeFaction");
+        var randomRoughFactionDef = DefDatabase<FactionDef>.GetNamedSilentFail("RF_RandomRoughFaction");
+        var randomPirateFactionDef = DefDatabase<FactionDef>.GetNamedSilentFail("RF_RandomPirateFaction");        
+
+        // Apply settings if the defs exist
+        if (randomFactionDef != null)
+        {
+            randomFactionDef.startingCountAtWorldCreation = SettingsInstance.randomFactionCount;
+            Logger.Trace($"Set RF_RandomFaction count to: {SettingsInstance.randomFactionCount}");
+        } else {
+            Logger.Warning("RF_RandomFaction def not found. Cannot apply randomFactionCount setting.");
+        }
+
+        if (randomRoughFactionDef != null)
+        {
+            randomRoughFactionDef.startingCountAtWorldCreation = SettingsInstance.randomRoughFactionCount;
+            Logger.Trace($"Set RF_RandomRoughFaction count to: {SettingsInstance.randomRoughFactionCount}");
+        } else {        
+            Logger.Warning("RF_RandomRoughFaction def not found. Cannot apply randomRoughFactionCount setting.");
+        }
+
+        if (randomPirateFactionDef != null)
+        {
+            randomPirateFactionDef.startingCountAtWorldCreation = SettingsInstance.randomPirateFactionCount;
+            Logger.Trace($"Set RF_RandomPirateFaction count to: {SettingsInstance.randomPirateFactionCount}");
+        } else {
+            Logger.Warning("RF_RandomPirateFaction def not found. Cannot apply randomPirateFactionCount setting.");
+        }
+
+        if (randomTradeFactionDef != null)
+        {
+            randomTradeFactionDef.startingCountAtWorldCreation = SettingsInstance.randomTradeFactionCount; 
+            Logger.Trace($"Set RF_RandomTradeFaction count to: {SettingsInstance.randomTradeFactionCount}");
+        } else {
+            Logger.Warning("RF_RandomTradeFaction def not found. Cannot apply randomTradeFactionCount setting.");
+        }
+
+        Logger.Trace("Faction count settings applied.");
+    }
+
     public override void DoSettingsWindowContents(Rect inRect)
     {
         var listing = new Listing_Standard();
@@ -348,6 +400,22 @@ public class RandomFactionsMod : Mod
 
         listing.Label("RaFa.xenotypePercent".Translate() + ": " + SettingsInstance.xenoPercent);
         SettingsInstance.xenoPercent = (int)listing.Slider(SettingsInstance.xenoPercent, 0f, 100f);
+
+        listing.Gap();
+
+        listing.Label("RaFa.randomFactionCount".Translate() + ": " + SettingsInstance.randomFactionCount);
+        SettingsInstance.randomFactionCount = (int)listing.Slider(SettingsInstance.randomFactionCount, 0f, 10f);
+
+        listing.Label("RaFa.randomTradeFactionCount".Translate() + ": " + SettingsInstance.randomTradeFactionCount);
+        SettingsInstance.randomTradeFactionCount = (int)listing.Slider(SettingsInstance.randomTradeFactionCount, 0f, 10f);
+
+        listing.Label("RaFa.randomRoughFactionCount".Translate() + ": " + SettingsInstance.randomRoughFactionCount);
+        SettingsInstance.randomRoughFactionCount = (int)listing.Slider(SettingsInstance.randomRoughFactionCount, 0f, 10f);
+
+        listing.Label("RaFa.randomPirateFactionCount".Translate() + ": " + SettingsInstance.randomPirateFactionCount);
+        SettingsInstance.randomPirateFactionCount = (int)listing.Slider(SettingsInstance.randomPirateFactionCount, 0f, 10f);
+
+        listing.Gap();
 
         listing.CheckboxLabeled(
             "RaFa.verboseLogging".Translate(),

--- a/Source/RandomFactions/RandomFactionsMod.cs
+++ b/Source/RandomFactions/RandomFactionsMod.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -69,6 +69,9 @@ public class RandomFactionsMod : Mod
         "HuntersCovenant", // Hunterphage
         "OutlanderPapou"
     ];
+
+    // don't disable these factions by default, as they are used in various DLC quests and scenarios, disabling breaks functionality
+    private static readonly HashSet<string> NotZeroedFactionDefs = new(StringComparer.OrdinalIgnoreCase) { "Empire", "Insect", "TradersGuild" };
 
     public static RandomFactionsSettings SettingsInstance;
 
@@ -313,10 +316,7 @@ public class RandomFactionsMod : Mod
     {
         foreach (var def in DefDatabase<FactionDef>.AllDefs)
         {
-            if (def.hidden ||
-                def.isPlayer ||
-                RandomCategoryName.EqualsIgnoreCase(def.categoryTag) ||
-                "Empire".EqualsIgnoreCase(def.defName))
+            if (def.hidden || def.isPlayer || RandomCategoryName.EqualsIgnoreCase(def.categoryTag) || NotZeroedFactionDefs.Contains(def.defName))
             {
                 continue;
             }


### PR DESCRIPTION
Small change:
- Define **NotZeroedFactionDefs**, a static cached hash set of the case-insensitive hashes of the names of factions not to be disabled
- Include **Empire**, **Insect**, and **TradersGuild** in **NotZeroedFactionDefs**
- Change **zeroCountFactionDefs** to check for membership of **NotZeroedFactionDefs** instead of Empire specifically

Justification:
- Supposedly having the HashSet instead of comparing strings is much faster
- Longer term, this will allow this HashSet to be edited in the settings window
- The Hive vs VFE: Insectoids random selection mod functionality was removed sometime before 3/23/2026, so Hive should no longer be disabled expecting that subroutine
- Odyssey uses Hive and Traders Guild for DLC functionality, just like Empire is used in Royalty for DLC functionality

Reason for not auto disabling these 3 specifically:
- **Empire**:  Required for some Royalty DLC functionality, already not disabled
- **Insect (Hive)**:  Required for lots of internal content, including Odyssey; game currently specifically warns not to disable or Odyssey DLC will lack functionality
- **Traders Guild**: Required for some Odyssey DLC functionality

My local compiled version of this seems to work fine but I did use autocomplete to puzzle my way through the C#, so an actual coder might want to double check.